### PR TITLE
Add missing gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,6 +16,7 @@ gem 'sass-rails'
 gem 'sprockets', '=2.11.0'
 gem 'jquery-rails'
 gem 'coffee-rails'
+gem 'uglifier'
 
 group :production do
   gem 'memcachier'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -160,6 +160,9 @@ GEM
       polyglot (>= 0.3.1)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
+    uglifier (2.5.3)
+      execjs (>= 0.3.0)
+      json (>= 1.8.0)
     unicorn (4.8.1)
       kgio (~> 2.6)
       rack
@@ -188,4 +191,5 @@ DEPENDENCIES
   sdoc
   sprockets (= 2.11.0)
   timecop
+  uglifier
   unicorn


### PR DESCRIPTION
@quipper/ruby 
deploying to production failed due to missing gem.
sorry bothering you :(
https://circleci.com/gh/quipper/deploy-support-tools/71
