### PR TITLE
Add endpoint to return staging url from github pull request url

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,7 @@ gem 'sprockets', '=2.11.0'
 gem 'jquery-rails'
 gem 'coffee-rails'
 gem 'uglifier'
+gem 'octokit'
 
 group :production do
   gem 'memcachier'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -27,6 +27,7 @@ GEM
       minitest (~> 5.1)
       thread_safe (~> 0.1)
       tzinfo (~> 1.1)
+    addressable (2.3.8)
     arel (5.0.1.20140414130214)
     bootstrap-sass (3.3.1.0)
       sass (~> 3.2)
@@ -58,6 +59,8 @@ GEM
       dotenv (= 1.0.2)
     erubis (2.7.0)
     execjs (2.2.2)
+    faraday (0.9.1)
+      multipart-post (>= 1.2, < 3)
     hike (1.2.3)
     hipchat (1.4.0)
       httparty
@@ -83,8 +86,11 @@ GEM
     minitest (5.4.3)
     multi_json (1.10.1)
     multi_xml (0.5.5)
+    multipart-post (2.0.0)
     nokogiri (1.6.5)
       mini_portile (~> 0.6.0)
+    octokit (3.8.0)
+      sawyer (~> 0.6.0, >= 0.5.3)
     pry (0.10.1)
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
@@ -141,6 +147,9 @@ GEM
       sass (~> 3.2.2)
       sprockets (~> 2.8, < 3.0)
       sprockets-rails (~> 2.0)
+    sawyer (0.6.0)
+      addressable (~> 2.3.5)
+      faraday (~> 0.8, < 0.10)
     sdoc (0.4.1)
       json (~> 1.7, >= 1.7.7)
       rdoc (~> 4.0)
@@ -184,6 +193,7 @@ DEPENDENCIES
   jbuilder (~> 1.2)
   jquery-rails
   memcachier
+  octokit
   pry-byebug
   rails (~> 4.1.0)
   rails_12factor

--- a/app/controllers/apps_controller.rb
+++ b/app/controllers/apps_controller.rb
@@ -1,5 +1,5 @@
 class AppsController < ApplicationController
-  http_basic_authenticate_with name: ENV["AUTH_USER"], password: ENV["AUTH_PASSWORD"], except: :create
+  http_basic_authenticate_with name: ENV["AUTH_USER"], password: ENV["AUTH_PASSWORD"], except: [:create, :staging_url]
 
   APPS_KEY = "apps"
 
@@ -22,5 +22,9 @@ class AppsController < ApplicationController
     kiosk.save
 
     render text: "#{app}-staging-#{app_number}"
+  end
+
+  def staging_url
+    render json: { text: StagingUrl.new(params[:text]).to_s }
   end
 end

--- a/app/models/staging_url.rb
+++ b/app/models/staging_url.rb
@@ -1,0 +1,47 @@
+class StagingUrl
+  def initialize(github_pull_request_url, github_api_token: nil, circleci_api_token: nil)
+    @github_pull_request_url = github_pull_request_url
+    @github_api_token   = github_api_token   || ENV['GITHUB_API_TOKEN']   || raise(ArgumentError.new("GITHUB_API_TOKEN is required."))
+    @circleci_api_token = circleci_api_token || ENV['CIRCLECI_API_TOKEN'] || raise(ArgumentError.new("CIRCLECI_API_TOKEN is required."))
+    parse
+    get_git_branch_name
+    get_heroku_url
+  end
+
+  def to_s
+    "https://#{@heroku_url.sub(/^quipper-/, '')}.quipper.net"
+  end
+
+  private
+
+  def parse
+    _, @user, @repo, @number = *Addressable::URI.parse(@github_pull_request_url).path.match(%r!\A/([^/]+)/([^/]+)/pull/(\d+)\z!)
+  end
+
+  def get_git_branch_name
+    @git_branch_name = Octokit::Client.new(access_token: @github_api_token).pull_request("#{@user}/#{@repo}", @number).head.ref
+  end
+
+  def get_heroku_url
+    # Get latest build of target branch
+    conn = Faraday.new(url: "https://circleci.com/")
+    response = conn.get do |req|
+      req.url "/api/v1/project/#{@user}/#{@repo}/tree/#{@git_branch_name}", limit: 1, filter: 'successful'
+      req.params['circle-token'] = @circleci_api_token
+    end
+    build = JSON.parse(response.body).first
+
+    # Get build step log of staging deploy
+    response = conn.get do |req|
+      req.url "/api/v1/project/#{@user}/#{@repo}/#{build['build_num']}"
+      req.params['circle-token'] = @circleci_api_token
+    end
+    step = JSON.parse(response.body)['steps'].detect { |step|
+      step['name'].match(/staging_deploy\.sh/)
+    }
+    response = Faraday.get step['actions'][0]['output_url']
+
+    # Extract deployed heroku app name
+    @heroku_url = JSON.parse(response.body)[0]['message'].match(/HEROKU_APP_NAME=(\S+)/)[1]
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,10 @@
 HerokuSupportTools::Application.routes.draw do
   root to: "apps#index"
-  resources :apps, only: [:index, :create]
+  resources :apps, only: [:index, :create] do
+    collection do
+      post :staging_url
+    end
+  end
   get '/scripts/production_deploy.sh(.:format)', to: 'scripts#production_deploy'
   get '/scripts/staging_deploy.sh(.:format)', to: 'scripts#staging_deploy'
   post '/notifications/hipchat', to: 'notifications#hipchat'


### PR DESCRIPTION
@quipper/developers 
This is supposed to be used with Slack's Outgoing Webhook.

Request/Response (private informations are masked in this example)

```
$ curl -X POST -i localhost:9999/apps/staging_url -d text=https://github.com/******/*****/pull/2994
HTTP/1.1 200 OK 
X-Frame-Options: SAMEORIGIN
X-Xss-Protection: 1; mode=block
X-Content-Type-Options: nosniff
Content-Type: application/json; charset=utf-8
Etag: "f73d90be5ae92b08f66180940324973d"
Cache-Control: max-age=0, private, must-revalidate
X-Request-Id: 6684ab47-b98b-4008-9add-a80c12c22b61
X-Runtime: 3.802335
Server: WEBrick/1.3.1 (Ruby/2.2.2/2015-04-13)
Date: Fri, 15 May 2015 04:20:31 GMT
Content-Length: 47
Connection: Keep-Alive

{"text":"https://qlink-staging-14.******.***"}
```