### PR TITLE
Always ensure to be success for git remote

### DIFF
--- a/app/views/scripts/production_deploy.erb
+++ b/app/views/scripts/production_deploy.erb
@@ -40,7 +40,7 @@ EOF
       heroku config:add HEROKU_APP_NAME="${herokuapp}" --app ${herokuapp}
       heroku labs:enable preboot --app ${herokuapp}
 
-      git remote add heroku-${herokuapp} git@heroku.com:${herokuapp}.git
+      git remote add heroku-${herokuapp} git@heroku.com:${herokuapp}.git || echo
       if ! GIT_TRACE=1 git push -f heroku-${herokuapp} ${CIRCLE_SHA1}:refs/heads/master; then
           rm -rf /home/ubuntu/${CIRCLE_PROJECT_REPONAME}
           cd /home/ubuntu


### PR DESCRIPTION
Sometimes `fatal: remote branch already exists. ` happens. 