### PR TITLE
Add a hook about pre-deployment

### DIFF
--- a/app/views/scripts/production_deploy.erb
+++ b/app/views/scripts/production_deploy.erb
@@ -25,6 +25,12 @@ if [ "${HEROKU_APPS}" == "" ]; then
   exit 1
 fi
 
+function prepare() {
+  if [ "$(type -t prepare_for_production_server)" == "function" ]; then
+    prepare_for_production_server
+  fi
+}
+
 function deploy() {
   cat > ${HOME}/.netrc <<EOF
 machine api.heroku.com
@@ -40,12 +46,14 @@ EOF
       heroku config:add HEROKU_APP_NAME="${herokuapp}" --app ${herokuapp}
       heroku labs:enable preboot --app ${herokuapp}
 
+      prepare
       git remote add heroku-${herokuapp} git@heroku.com:${herokuapp}.git || echo
       if ! GIT_TRACE=1 git push -f heroku-${herokuapp} ${CIRCLE_SHA1}:refs/heads/master; then
           rm -rf /home/ubuntu/${CIRCLE_PROJECT_REPONAME}
           cd /home/ubuntu
           git clone git@github.com:${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}.git
           cd ${CIRCLE_PROJECT_REPONAME}
+          prepare
           git reset --hard ${CIRCLE_SHA1}  # this isn't strictly necessary
           GIT_TRACE=1 git push -f heroku-${herokuapp} ${CIRCLE_SHA1}:refs/heads/master
       fi


### PR DESCRIPTION
@quipper/web-devs @quipper/engineering 
This is mainly to fix qlink deployment error via CircleCI 
e.g
- https://circleci.com/gh/quipper/qlink/15799

Deploy script of qlink make new commit and rewrite `CIRCLE_SHA1` in the deploy script.
- https://github.com/quipper/qlink/blob/19a9751480e0d5d644f5ac97cde9827baf59a6df/script/npm_support
- https://github.com/quipper/qlink/blob/9464f271040a8e76bd135c898c31b8d20ea2fbee/script/production_deploy.sh#L9

So when retrying to deploy (`git push`), git ends up referring to not existing `CIRCLE_SHA1`.
https://github.com/quipper/deploy-support-tools/blob/547c1562d9f2d2a81a4e47b9c81f746cd5a0cdf2/app/views/scripts/production_deploy.erb#L50

Therefore I added a hook for preparation of deploy, thanks.