### PR TITLE
Do not join app when production deploy.

### DIFF
--- a/app/views/scripts/production_deploy.erb
+++ b/app/views/scripts/production_deploy.erb
@@ -42,7 +42,6 @@ EOF
 
   for herokuapp in ${HEROKU_APPS}
   do
-      heroku join --app ${herokuapp}
       heroku config:add HEROKU_APP_NAME="${herokuapp}" --app ${herokuapp}
       heroku labs:enable preboot --app ${herokuapp}
 


### PR DESCRIPTION
Because of Heroku specification change, team admin cannot join to
individual application.