### PR TITLE
Ignore error when enable preboot feature.

### DIFF
--- a/app/views/scripts/production_deploy.erb
+++ b/app/views/scripts/production_deploy.erb
@@ -43,7 +43,7 @@ EOF
   for herokuapp in ${HEROKU_APPS}
   do
       heroku config:add HEROKU_APP_NAME="${herokuapp}" --app ${herokuapp}
-      heroku labs:enable preboot --app ${herokuapp}
+      heroku features:enable --app ${herokuapp} preboot || :
 
       prepare
       git remote add heroku-${herokuapp} git@heroku.com:${herokuapp}.git || echo


### PR DESCRIPTION
Because free or hobby dyno does not support the feature.
For more detail, see https://devcenter.heroku.com/articles/preboot