### PR TITLE
Persist GitHub RepoConfig

### DIFF
--- a/app/controllers/apps_controller.rb
+++ b/app/controllers/apps_controller.rb
@@ -11,6 +11,7 @@ class AppsController < ApplicationController
     app = params["app"] || raise("app is not set")
     branch = params["branch"] || raise("branch is not set")
     servers = (params["servers"] || 4).to_i
+    repo_name = params["repo_name"]
 
     apps = Rails.cache.read(APPS_KEY) || []
     apps << app
@@ -20,6 +21,13 @@ class AppsController < ApplicationController
     kiosk = App.new app, servers
     app_number = kiosk.lottery branch
     kiosk.save
+
+    repo_config = RepoConfig.new(
+      repo_name: repo_name,
+      app_prefix: app,
+      max_entries: servers,
+    )
+    repo_config.save if repo_config.valid?
 
     render text: "#{app}-staging-#{app_number}"
   end

--- a/app/models/repo_config.rb
+++ b/app/models/repo_config.rb
@@ -1,0 +1,39 @@
+require 'active_model'
+
+class RepoConfig
+  include ActiveModel::Model
+
+  attr_accessor :app_prefix, :repo_name, :max_entries
+  attr_reader :store
+
+  validates :app_prefix, presence: true
+  validates :repo_name, presence: true
+  validates :max_entries,
+    presence: true,
+    numericality: {only_integer: true, greater_than_or_equal_to: 0}
+
+  def self.find_by_repo_name(repo_name)
+    config = Rails.cache.read("config-#{repo_name}")
+    config ? self.new(config) : nil
+  end
+
+  def initialize(attrs)
+    @store = attrs.delete(:store) || Rails.cache
+    super(attrs)
+  end
+
+  def save
+    store.write name, attributes
+  end
+
+  def name
+    "repo_config-#{repo_name}"
+  end
+
+  def attributes
+    {
+      app_prefix: app_prefix,
+      max_entries: max_entries,
+    }
+  end
+end

--- a/app/models/repo_config.rb
+++ b/app/models/repo_config.rb
@@ -1,6 +1,8 @@
 require 'active_model'
 
 class RepoConfig
+  CACHE_KEY_PREFIX = 'repo_config'
+
   include ActiveModel::Model
 
   attr_accessor :app_prefix, :repo_name, :max_entries
@@ -13,7 +15,7 @@ class RepoConfig
     numericality: {only_integer: true, greater_than_or_equal_to: 0}
 
   def self.find_by_repo_name(repo_name)
-    config = Rails.cache.read("config-#{repo_name}")
+    config = Rails.cache.read("#{CACHE_KEY_PREFIX}-#{repo_name}")
     config ? self.new(config) : nil
   end
 
@@ -27,7 +29,7 @@ class RepoConfig
   end
 
   def name
-    "repo_config-#{repo_name}"
+    "#{CACHE_KEY_PREFIX}-#{repo_name}"
   end
 
   def attributes

--- a/spec/controllers/apps_controller_spec.rb
+++ b/spec/controllers/apps_controller_spec.rb
@@ -1,7 +1,7 @@
 require "spec_helper"
 
 describe AppsController do
-  describe 'index' do
+  describe '#index' do
     before do
       http_login
     end
@@ -25,8 +25,8 @@ describe AppsController do
     end
   end
 
-  describe "Find or create app name" do
-    it "responds successfully with an HTTP 200 status code" do
+  describe "#create" do
+    it "responds successfully with an HTTP 200 status code and app name" do
       post :create, app: "foo", branch: "feature-bar"
       expect(response).to be_success
       expect(response.body).to eql("foo-staging-1")

--- a/spec/controllers/apps_controller_spec.rb
+++ b/spec/controllers/apps_controller_spec.rb
@@ -54,7 +54,7 @@ describe AppsController do
       end
 
       it "persists repo config into Rails.cache" do
-        expect(store.read('repo_config-quipper/foo')).to eq({app_prefix: 'foo', max_entries: 10})
+        expect(store.read("#{RepoConfig::CACHE_KEY_PREFIX}-quipper/foo")).to eq({app_prefix: 'foo', max_entries: 10})
       end
     end
   end

--- a/spec/controllers/apps_controller_spec.rb
+++ b/spec/controllers/apps_controller_spec.rb
@@ -26,10 +26,36 @@ describe AppsController do
   end
 
   describe "#create" do
-    it "responds successfully with an HTTP 200 status code and app name" do
-      post :create, app: "foo", branch: "feature-bar"
-      expect(response).to be_success
-      expect(response.body).to eql("foo-staging-1")
+    let(:store) { ActiveSupport::Cache::MemoryStore.new }
+
+    before do
+      allow(Rails).to receive(:cache) { store }
+    end
+
+    context 'without repo_name' do
+      before do
+        post :create, app: "foo", branch: "feature-bar"
+      end
+
+      it "responds successfully with an HTTP 200 status code and app name" do
+        expect(response).to be_success
+        expect(response.body).to eql("foo-staging-1")
+      end
+    end
+
+    context 'with repo_name' do
+      before do
+        post :create, app: "foo", branch: "feature-bar", servers: 10, repo_name: "quipper/foo"
+      end
+
+      it "responds successfully with an HTTP 200 status code and app name" do
+        expect(response).to be_success
+        expect(response.body).to eql("foo-staging-1")
+      end
+
+      it "persists repo config into Rails.cache" do
+        expect(store.read('repo_config-quipper/foo')).to eq({app_prefix: 'foo', max_entries: 10})
+      end
     end
   end
 end

--- a/spec/models/repo_config_spec.rb
+++ b/spec/models/repo_config_spec.rb
@@ -1,0 +1,32 @@
+require 'spec_helper'
+
+describe RepoConfig do
+  let(:store) { ActiveSupport::Cache::MemoryStore.new }
+
+  describe '#name' do
+    let(:repo_config) { RepoConfig.new(repo_name: 'quipper/foo', store: store) }
+
+    subject { repo_config.name }
+
+    it { is_expected.to eq 'repo_config-quipper/foo' }
+  end
+
+  describe '#save' do
+    let(:repo_config) do
+      repo_config = RepoConfig.new(
+        repo_name: 'quipper/foo',
+        app_prefix: 'foo',
+        max_entries: 10,
+        store: store,
+      )
+    end
+
+    it 'persists attributes in cache store' do
+      expect {
+        repo_config.save
+      }.to change {
+        store.read(repo_config.name)
+      }.from(nil).to({app_prefix: 'foo', max_entries: 10})
+    end
+  end
+end


### PR DESCRIPTION
ref: https://github.com/quipper/deploy-support-tools/issues/63

When I'm implementing https://github.com/quipper/deploy-support-tools/pull/62, I noticed that there is no way to know below parameters in webhook context.

* app prefix
* server count

Currently they are only passed to `POST /apps` as parameters and not persisted.

So as a first step, I want to persist them into `Rails.cache` in `POST /apps` action.
And I'll implement https://github.com/quipper/deploy-support-tools/pull/62 after this PR is merged.

Please review and merge.