### PR TITLE
Send repo_name when registering apps

### DIFF
--- a/app/views/scripts/staging_deploy.erb
+++ b/app/views/scripts/staging_deploy.erb
@@ -96,7 +96,7 @@ function build_url() {
 }
 
 function notify_all() {
-  HEROKU_APP_NAME=`curl <%= ENV['DEPLOY_SUPPORT_TOOL_URL'] %>/apps --data "app=${STAGING_APP_PREFIX}&branch=${CIRCLE_BRANCH}&servers=${NUM_OF_STAGING_SERVERS}"`
+  HEROKU_APP_NAME=`curl <%= ENV['DEPLOY_SUPPORT_TOOL_URL'] %>/apps --data "app=${STAGING_APP_PREFIX}&branch=${CIRCLE_BRANCH}&servers=${NUM_OF_STAGING_SERVERS}&repo_name=${REPO_NAME}"`
   if [ "${HEROKU_APP_NAME}" == "" ]; then
     echo "failed to get a staging app name"
     exit 1


### PR DESCRIPTION
@quipper/web-devs 
`repo_name` is saved into `RepoConfig`
https://github.com/quipper/deploy-support-tools/blob/f448b75e802a610ae2007d9caea42563ab4a9983/app/controllers/apps_controller.rb#L26
When handling `pull_request` webhook, it's needed to know what the app is in `App`.
https://github.com/quipper/deploy-support-tools/blob/d9e5834fef3429ad466d3f2cf8c91df758fb56f4/app/controllers/webhook_controller.rb#L12

`repo_name` is a `String` like: `"quipper/deploy-support-tools"`.

Details of webhook: https://github.com/quipper/deploy-support-tools/pull/62

Please review!