### PR TITLE
Fix Parameter Key of Webhook Payload

### DIFF
--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -7,7 +7,7 @@ class WebhookController < ApplicationController
       return
     end
 
-    webhook = JSON.parse(params[:webhook]) rescue {}
+    webhook = JSON.parse(params[:payload]) rescue {}
     repo_name = webhook.dig('pull_request', 'base', 'repo', 'full_name')
     repo_config = RepoConfig.find_by_repo_name(repo_name)
 

--- a/spec/controllers/webhook_controller_spec.rb
+++ b/spec/controllers/webhook_controller_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe WebhookController, type: :controller do
 
         subject do
           request.headers['X-GitHub-Event'] = 'pull_request'
-          post :receive, {webhook: webhook_params.to_json}
+          post :receive, {payload: webhook_params.to_json}
         end
 
         before do


### PR DESCRIPTION
@quipper/web-devs 

ref: https://github.com/quipper/deploy-support-tools/issues/63

The key is not `webhook` but `payload` 🙇 
https://developer.github.com/webhooks/creating/#content-type

BTW, `deploy-support-tools` expects the `Content-Type` as `application/x-www-form-urlencoded`.
It's because `params[:action]` is overridden by Rails even though it's needed.

![image](https://cloud.githubusercontent.com/assets/241542/24917374/efc26942-1f17-11e7-9c9f-e1afb7c47796.png)
