### PR TITLE
Detect an error of git push for staging scripts

### DIFF
--- a/app/views/scripts/staging_deploy.erb
+++ b/app/views/scripts/staging_deploy.erb
@@ -67,7 +67,7 @@ EOF
 
   # https://github.com/quipper/deploy-support-tools/pull/5#issuecomment-36588889
   [[ ! -s "$(git rev-parse --git-dir)/shallow" ]] || git fetch --unshallow
-  GIT_TRACE=1 git push -f heroku ${CIRCLE_SHA1}:refs/heads/master
+  GIT_TRACE=1 git push -f heroku ${CIRCLE_SHA1}:refs/heads/master || exit $?
 
   notify_all
 }


### PR DESCRIPTION
refs: https://github.com/quipper/deploy-support-tools/pull/58

### Overview

* `git push heroku master` returns non-zero status code

```
DEV banyan ☁  cat config.ru
run lambda { |env| [200, {'Content-Type'=>'text/plain'}, StringIO.new("Hello World!\n")] }
DEV banyan ☁  cat Gemfile
source 'https://rubygems.org'
gem 'rack'
gem 'listen' if RUBY_PLATFORM =~ /darwin/
DEV banyan ☁  git push heroku master
...
remote:        You have deleted from the Gemfile:
remote:        * listen
remote:  !
remote:  !     Failed to install gems via Bundler.
remote:  !
remote:  !     Push rejected, failed to compile Ruby app.
remote:
remote:  !     Push failed
remote: Verifying deploy...
remote:
remote: !       Push rejected to test-banyan.
remote:
To https://git.heroku.com/test-banyan.git
 ! [remote rejected] master -> master (pre-receive hook declined)
error: failed to push some refs to 'https://git.heroku.com/test-banyan.git'
DEV banyan ☁  echo $?
1
```

* `app/views/scripts/staging_deploy.erb` doesn't have `e` option. Each app's script has `e` option though. so it doesn't fail immediately.

```
DEV banyan ☁  cat foo.sh
function deploy() {
    ls | foo
}
DEV banyan ☁  cat bar.sh
. foo.sh
deploy
echo "hi"
DEV banyan ☁  sh bar.sh
foo.sh: line 4: foo: command not found
hi
```
```
DEV banyan ☁  cat foo.sh
set -e # Use e option

function deploy() {
    ls | foo
}                                                                                                                          [~]
DEV banyan ☁  sh bar.sh
foo.sh: line 4: foo: command not found
```

* Adding `e` option in `app/views/scripts/staging_deploy.erb`  also would work, However, It expects to show an error (validation) message here: https://github.com/quipper/deploy-support-tools/blob/cb840228b7bf4326b99b71d80b4f113ac5143692/app/views/scripts/staging_deploy.erb#L1-L34, so I think just adding `exit` is _better_ (well... easy for me 😝 )

Please review and merge @yuya-takeyama @kachick @quipper/web-devs 


<details>
<summary>Sample output</summary>

```
DEV banyan ☁  cat a.sh
#!/bin/bash -x

git push heroku master || exit $?
echo "hi"
```

```
DEV banyan ☁  ./a.sh                                                                                                                   [18/751]
+ git push heroku master
Counting objects: 8, done.
Delta compression using up to 8 threads.
Compressing objects: 100% (7/7), done.
Writing objects: 100% (8/8), 944 bytes | 0 bytes/s, done.
Total 8 (delta 1), reused 0 (delta 0)
remote: Compressing source files... done.
remote: Building source:
remote:
remote: -----> Ruby app detected
remote: -----> Compiling Ruby/Rack
remote: -----> Using Ruby version: ruby-2.3.4
remote: ###### WARNING:
remote:        You have the `.bundle/config` file checked into your repository
remote:        It contains local state like the location of the installed bundle
remote:        as well as configured git local gems, and other settings that should
remote:        not be shared between multiple checkouts of a single repo. Please
remote:        remove the `.bundle/` folder from your repo and add it to your `.gitignore` file.
remote:        https://devcenter.heroku.com/articles/bundler-configuration
remote:
remote: -----> Installing dependencies using bundler 1.13.7
remote:        Running: bundle install --without development:test --path vendor/bundle --binstubs vendor/bundle/bin -j4 --deployment
remote:        Warning: the running version of Bundler (1.13.7) is older than the version that created the lockfile (1.14.6). We suggest you up
grade to the latest version of Bundler by running `gem install bundler`.
remote:        You are trying to install in deployment mode after changing
remote:        your Gemfile. Run `bundle install` elsewhere and add the
remote:        updated Gemfile.lock to version control.
remote:        You have deleted from the Gemfile:
remote:        * listen
remote:        Bundler Output: Warning: the running version of Bundler (1.13.7) is older than the version that created the lockfile (1.14.6). W
e suggest you upgrade to the latest version of Bundler by running `gem install bundler`.
remote:        You are trying to install in deployment mode after changing
remote:        your Gemfile. Run `bundle install` elsewhere and add the
remote:        updated Gemfile.lock to version control.
remote:
remote:        You have deleted from the Gemfile:
remote:        * listen
remote:  !
remote:  !     Failed to install gems via Bundler.
remote:  !
remote:  !     Push rejected, failed to compile Ruby app.
remote:
remote:  !     Push failed
remote: Verifying deploy....
remote:
remote: !       Push rejected to test-banyan.
remote:
To https://git.heroku.com/test-banyan.git
 ! [remote rejected] master -> master (pre-receive hook declined)
error: failed to push some refs to 'https://git.heroku.com/test-banyan.git'
+ exit 1
DEV banyan ☁  echo $?
1
```
</details>
