### PR TITLE
Remove BUNDLE_WITHOUT config set from deploy_staging

### DIFF
--- a/app/views/scripts/production_deploy.erb
+++ b/app/views/scripts/production_deploy.erb
@@ -46,7 +46,7 @@ EOF
   for herokuapp in ${HEROKU_APPS}
   do
       heroku config:add HEROKU_APP_NAME="${herokuapp}" --app ${herokuapp}
-      heroku config:set BUNDLE_WITHOUT="development:test:darwin" --app ${herokuapp}
+      heroku config:add BUNDLE_WITHOUT="development:test:darwin" --app ${herokuapp}
       heroku features:enable --app ${herokuapp} preboot || :
 
       prepare

--- a/app/views/scripts/staging_deploy.erb
+++ b/app/views/scripts/staging_deploy.erb
@@ -62,7 +62,6 @@ EOF
   heroku git:remote --ssh-git --app ${HEROKU_APP_NAME} || heroku create ${HEROKU_APP_NAME} ${OPTION_HEROKU_ORGANIZATION}
   heroku config:add HEROKU_APP_NAME="${HEROKU_APP_NAME}" --app ${HEROKU_APP_NAME}
   heroku config:add GIT_COMMIT_SHA1=${CIRCLE_SHA1} --app ${HEROKU_APP_NAME}
-  heroku config:set BUNDLE_WITHOUT="development:test:darwin" --app ${HEROKU_APP_NAME}
 
   prepare_for_staging_server
 


### PR DESCRIPTION
This PR reverts https://github.com/quipper/deploy-support-tools/pull/73 and https://github.com/quipper/deploy-support-tools/pull/74 .
Actually I don't have to set `BUNDLE_WITHOUT` here 😓 